### PR TITLE
Store index in node

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cockroachdb/pebble v1.1.0
 	github.com/consensys/gnark-crypto v0.12.2-0.20240215234832-d72fcb379d3e
 	github.com/ethereum/go-ethereum v1.14.0
-	github.com/mdehoog/indexed-merkle-tree v0.0.0-20240420075202-4a8258bb7064
+	github.com/mdehoog/indexed-merkle-tree v0.0.0-20240501232025-1a1fd8909d63
 	github.com/wealdtech/go-merkletree/v2 v2.5.1
 )
 

--- a/go/go.sum
+++ b/go/go.sum
@@ -191,8 +191,8 @@ github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/mdehoog/indexed-merkle-tree v0.0.0-20240420075202-4a8258bb7064 h1:uRjAPslep9/qPqKjDq4K6G78WUJCFwfb3DRgQsbwBjI=
-github.com/mdehoog/indexed-merkle-tree v0.0.0-20240420075202-4a8258bb7064/go.mod h1:48kgV1+OSRrFXTMtRaDjouD8R7iInBsm/jNKAxVf//I=
+github.com/mdehoog/indexed-merkle-tree v0.0.0-20240501232025-1a1fd8909d63 h1:pB2KAi7t177kut4a03zFuMkxj+slWyk4Vemi2XrvDLE=
+github.com/mdehoog/indexed-merkle-tree v0.0.0-20240501232025-1a1fd8909d63/go.mod h1:48kgV1+OSRrFXTMtRaDjouD8R7iInBsm/jNKAxVf//I=
 github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iPfkHRY=
 github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqkyU72HC5wJ4RlU=
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=

--- a/go/main.go
+++ b/go/main.go
@@ -32,7 +32,6 @@ func main() {
 
 	if os.Args[1] == "getTreeRoot" {
 		getTreeRoot(tree)
-
 	} else if os.Args[1] == "getInclusionProof" {
 		key, success := new(big.Int).SetString(os.Args[2], 10)
 		if !success {
@@ -40,14 +39,13 @@ func main() {
 			os.Exit(1)
 		}
 		getInclusionProof(key, tree)
-
 	} else if os.Args[1] == "getExclusionProof" {
 		key, success := new(big.Int).SetString(os.Args[2], 10)
 		if !success {
 			fmt.Println("Error parsing key argument:", os.Args[2])
 			os.Exit(1)
 		}
-		getExcluisonProof(key, tree)
+		getExclusionProof(key, tree)
 	} else if os.Args[1] == "testHash" {
 		a, successA := new(big.Int).SetString(os.Args[2], 10)
 		if !successA {
@@ -63,17 +61,17 @@ func main() {
 	}
 }
 
-func getTreeRoot(t *imt.TreeWriter) {
+func getTreeRoot(t imt.TreeWriter) {
 	root, _ := t.Root()
 	fmt.Println(hexutil.Encode(padBytes(root.Bytes(), 32)))
 }
 
-func getInclusionProof(key *big.Int, t *imt.TreeWriter) {
+func getInclusionProof(key *big.Int, t imt.TreeWriter) {
 	inclusionProof, _ := t.ProveInclusion(key)
 	_encodeForFoundry(inclusionProof)
 }
 
-func getExcluisonProof(key *big.Int, t *imt.TreeWriter) {
+func getExclusionProof(key *big.Int, t imt.TreeWriter) {
 	exclusionProof, _ := t.ProveExclusion(key)
 	_encodeForFoundry(exclusionProof)
 }
@@ -86,18 +84,18 @@ func testHash(a *big.Int, b *big.Int) {
 	fmt.Println(h)
 }
 
-func _encodeForFoundry(p *imt.Proof) {
+func _encodeForFoundry(p imt.Proof) {
 	// Encode the tree-data for the proof
 	// Solidity structs head memory locations
 	// struct Proof {
 	//     bytes32 root;			// 0x20
 	//     uint256 size;			// 0x40
-	//     uint256 index;			// 0x60
-	//     Node node;				// 0x80-0xc0
+	//     Node node;				// 0x60-0xc0
 	//     uint256[] siblings;		// 0xe0
 	// }
 	// struct Node {
 	//     uint256 key;
+	//     uint256 index;
 	//     uint256 value;
 	//     uint256 nextKey;
 	// }
@@ -105,23 +103,23 @@ func _encodeForFoundry(p *imt.Proof) {
 	tupleHead, _ := hexutil.Decode("0x20")
 	head := hexutil.Encode(padBytes(tupleHead, 32))
 	// Encode the data
-	root := hexutil.Encode(padBytes(p.Root.Bytes(), 32))
-	size := hexutil.Encode(padBytes(Uint64ToBytes(p.Size), 32))
-	index := hexutil.Encode(padBytes(Uint64ToBytes(p.Index), 32))
-	nodeKey := hexutil.Encode(padBytes(p.Node.Key.Bytes(), 32))
-	nodeValue := hexutil.Encode(padBytes(p.Node.Value.Bytes(), 32))
-	nodeNext := hexutil.Encode(padBytes(p.Node.NextKey.Bytes(), 32))
-	result := head + root[2:] + size[2:] + index[2:] + nodeKey[2:] + nodeValue[2:] + nodeNext[2:]
+	root := hexutil.Encode(padBytes(p.Root().Bytes(), 32))
+	size := hexutil.Encode(padBytes(Uint64ToBytes(p.Size()), 32))
+	nodeKey := hexutil.Encode(padBytes(p.Node().Key().Bytes(), 32))
+	index := hexutil.Encode(padBytes(Uint64ToBytes(p.Node().Index()), 32))
+	nodeValue := hexutil.Encode(padBytes(p.Node().Value().Bytes(), 32))
+	nodeNext := hexutil.Encode(padBytes(p.Node().NextKey().Bytes(), 32))
+	result := head + root[2:] + size[2:] + nodeKey[2:] + index[2:] + nodeValue[2:] + nodeNext[2:]
 
 	// Encode the head location of the dynamicly set data
 	headLocation, _ := hexutil.Decode("0xe0")
 	result += hexutil.Encode(padBytes(headLocation, 32))[2:]
 	// Encode the length of the array for dyanamic var assignment w/ abi.decode()
-	result += hexutil.Encode(padBytes(Uint64ToBytes(uint64(len(p.Siblings))), 32))[2:]
+	result += hexutil.Encode(padBytes(Uint64ToBytes(uint64(len(p.Siblings()))), 32))[2:]
 
 	// Encode the members of the array
-	for i := 0; i < len(p.Siblings); i++ {
-		result += hexutil.Encode(padBytes(p.Siblings[i].Bytes(), 32))[2:]
+	for i := 0; i < len(p.Siblings()); i++ {
+		result += hexutil.Encode(padBytes(p.Siblings()[i].Bytes(), 32))[2:]
 	}
 	// valid, _ := inclusionProof.Valid(&t.TreeReader)
 	// fmt.Println(valid)

--- a/src/IndexedMerkleTree.sol
+++ b/src/IndexedMerkleTree.sol
@@ -67,8 +67,8 @@ library IndexedMerkleTree {
     ///
     /// @param proof A complete proof struct which describes the tree and the associated
     /// data necessary to validate a provided node.
-    /// @param hashNode The hasing method to hash the node.
-    /// @param hashPair The hasing method to hash pairs.
+    /// @param hashNode The hashing method to hash the node.
+    /// @param hashPair The hashing method to hash pairs.
     function _verify(
         Proof memory proof,
         function (Node memory) pure returns (uint256) hashNode,

--- a/src/IndexedMerkleTree.sol
+++ b/src/IndexedMerkleTree.sol
@@ -11,12 +11,13 @@ import {PoseidonT4} from "poseidon-solidity/PoseidonT4.sol";
 /// according to the structures provided.
 /// Be sure to strictly pair trees and proofs with a specific hashing algorithm. This library implements
 /// a mechanism for validating trees hashed using keccak256 or Poseidon as the hashing function.
-
 library IndexedMerkleTree {
     /// @notice A Node represents a single leaf in an IMT
     struct Node {
         /// @dev The unique identifier in the tree upon which the tree is sorted
         uint256 key;
+        /// @dev The node index.
+        uint256 index;
         /// @dev The value associated with this key
         uint256 value;
         /// @dev The linked-list property of an IMT depends on each node knowing the next
@@ -31,8 +32,6 @@ library IndexedMerkleTree {
         bytes32 root;
         /// @dev The tree's size
         uint256 size;
-        /// @dev The index of the leaf node being proved
-        uint256 index;
         /// @dev The Node struct containing the details for the leaf node
         Node node;
         ///@dev The sibling proof list, similar to other Merkle Tree proofs
@@ -48,7 +47,7 @@ library IndexedMerkleTree {
     /// data necessary to validate a provided node.
     function verify(Proof memory proof) internal pure returns (bool) {
         uint256 computedHash = _hashNode(proof.node);
-        uint256 index = proof.index;
+        uint256 index = proof.node.index;
         for (uint256 level = proof.siblings.length; level > 0; index /= 2) {
             level--;
             uint256 sibling = proof.siblings[level];
@@ -64,14 +63,6 @@ library IndexedMerkleTree {
         return bytes32(computedHash) == proof.root;
     }
 
-    function _hashPair(uint256 a, uint256 b) private pure returns (uint256) {
-        return uint256(keccak256(abi.encode(a, b)));
-    }
-
-    function _hashNode(Node memory node) private pure returns (uint256) {
-        return uint256(keccak256(abi.encode(node.key, node.value, node.nextKey)));
-    }
-
     /// @notice The verification method which determines that a proof is valid when using Poseidon hashes
     ///
     /// @dev Ensure proofs are generated using the golang lib linked above
@@ -81,7 +72,7 @@ library IndexedMerkleTree {
     /// data necessary to validate a provided node.
     function verifyPoseidon(Proof memory proof) internal pure returns (bool) {
         uint256 computedHash = _poseidonHashNode(proof.node);
-        uint256 index = proof.index;
+        uint256 index = proof.node.index;
         for (uint256 level = proof.siblings.length; level > 0; index /= 2) {
             level--;
             uint256 sibling = proof.siblings[level];
@@ -97,13 +88,21 @@ library IndexedMerkleTree {
         return bytes32(computedHash) == proof.root;
     }
 
-    function _poseidonHashPair(uint256 a, uint256 b) private pure returns (uint256) {
-        uint256[2] memory _pair = [a, b];
-        return PoseidonT3.hash(_pair);
+    function _hashNode(Node memory node) private pure returns (uint256) {
+        return uint256(keccak256(abi.encode(node.key, node.value, node.nextKey)));
+    }
+
+    function _hashPair(uint256 a, uint256 b) private pure returns (uint256) {
+        return uint256(keccak256(abi.encode(a, b)));
     }
 
     function _poseidonHashNode(Node memory node) private pure returns (uint256) {
         uint256[3] memory _node = [node.key, node.value, node.nextKey];
         return PoseidonT4.hash(_node);
+    }
+
+    function _poseidonHashPair(uint256 a, uint256 b) private pure returns (uint256) {
+        uint256[2] memory _pair = [a, b];
+        return PoseidonT3.hash(_pair);
     }
 }

--- a/test/IndexedMerkleTree.t.sol
+++ b/test/IndexedMerkleTree.t.sol
@@ -24,14 +24,16 @@ contract IndexedMerkleTreeTest is Test {
 
     function _goGetTree() internal returns (bytes32) {
         string[] memory inputs = new string[](2);
-        inputs[0] = "test/../go/imt";
+        string memory rootdir = vm.projectRoot();
+        inputs[0] = string.concat(rootdir, "/go/imt");
         inputs[1] = "getTreeRoot";
         return abi.decode(vm.ffi(inputs), (bytes32));
     }
 
     function _goGetIncProof(uint256 key) internal returns (IndexedMerkleTree.Proof memory) {
         string[] memory inputs = new string[](3);
-        inputs[0] = "test/../go/imt";
+        string memory rootdir = vm.projectRoot();
+        inputs[0] = string.concat(rootdir, "/go/imt");
         inputs[1] = "getInclusionProof";
         inputs[2] = key.toString();
         return abi.decode(vm.ffi(inputs), (IndexedMerkleTree.Proof));
@@ -39,7 +41,8 @@ contract IndexedMerkleTreeTest is Test {
 
     function _goGetExcProof(uint256 key) internal returns (IndexedMerkleTree.Proof memory) {
         string[] memory inputs = new string[](3);
-        inputs[0] = "test/../go/imt";
+        string memory rootdir = vm.projectRoot();
+        inputs[0] = string.concat(rootdir, "/go/imt");
         inputs[1] = "getExclusionProof";
         inputs[2] = key.toString();
         return abi.decode(vm.ffi(inputs), (IndexedMerkleTree.Proof));


### PR DESCRIPTION
This PR upgrades the contract to handle the `index` being stored on the `Node` struct following https://github.com/mdehoog/indexed-merkle-tree/pull/1.

The 2nd commit (93d5e07e18a4c30765579a87b4d8218f7558e66b) adds a generic template wrapper around the verify algorithm.